### PR TITLE
Started implementing schema builder struct handling

### DIFF
--- a/model/builder.go
+++ b/model/builder.go
@@ -4,13 +4,33 @@ package model
 
 type Swagger_Builder struct{ n *Swagger }
 
-func NewSwagger() Swagger_Builder                             { return Swagger_Builder{new(Swagger)} }
-func (b Swagger_Builder) Info(n Info_Builder) Swagger_Builder { b.n.Info = n.Build(); return b }
-func (b Swagger_Builder) Host(s string) Swagger_Builder       { b.n.Host = s; return b }
-func (b Swagger_Builder) Build() Swagger                      { return *b.n }
+func NewSwagger() *Swagger_Builder                             {
+	builder := &Swagger_Builder{new(Swagger)}
+	builder.n.Paths = map[string]*PathItem{}
+	builder.n.Definitions = map[string]*Schema{}
+	builder.n.Swagger = "2.0"
+	return builder
+}
+func (b *Swagger_Builder) Info(n Info_Builder) *Swagger_Builder { b.n.Info = n.Build(); return b }
+func (b *Swagger_Builder) Host(s string) *Swagger_Builder       { b.n.Host = s; return b }
+func (b *Swagger_Builder) Build() *Swagger                      { return b.n }
+func (b *Swagger_Builder) Path(path string, pathItem *PathItem) *Swagger_Builder {
+	b.n.Paths[path] = pathItem
+	return b
+}
+func (b *Swagger_Builder) Definitions(definitions map[string]*Schema) *Swagger_Builder {
+	for key, value := range definitions {
+		b.n.Definitions[key] = value
+	}
+	return b
+}
 
 type Info_Builder struct{ n *Info }
 
-func NewInfo() Info_Builder                        { return Info_Builder{new(Info)} }
+func NewInfo() Info_Builder                        {
+	builder := Info_Builder{new(Info)}
+	builder.n.Version = "1.0.0"
+	return builder
+}
 func (b Info_Builder) Title(s string) Info_Builder { b.n.Title = s; return b }
 func (b Info_Builder) Build() Info                 { return *b.n }

--- a/model/builder.go
+++ b/model/builder.go
@@ -4,7 +4,7 @@ package model
 
 type Swagger_Builder struct{ n *Swagger }
 
-func NewSwagger() *Swagger_Builder                             {
+func NewSwagger() *Swagger_Builder {
 	builder := &Swagger_Builder{new(Swagger)}
 	builder.n.Paths = map[string]*PathItem{}
 	builder.n.Definitions = map[string]*Schema{}
@@ -27,7 +27,7 @@ func (b *Swagger_Builder) Definitions(definitions map[string]*Schema) *Swagger_B
 
 type Info_Builder struct{ n *Info }
 
-func NewInfo() Info_Builder                        {
+func NewInfo() Info_Builder {
 	builder := Info_Builder{new(Info)}
 	builder.n.Version = "1.0.0"
 	return builder

--- a/model/common.go
+++ b/model/common.go
@@ -1,13 +1,13 @@
 package model
 
 type Swagger struct {
-	Swagger string `json:"swagger"`
-	Info    Info   `json:"info"`
-	Host    string `json:"host"`
-	BasePath string `json:"basePath,omitempty"`
-	Schemes []string `json:"schemes,omitempty"`
-	Paths   map[string]*PathItem `json:"paths"` // Ignoring extensions for now
-	Definitions map[string]*Schema `json:"definitions"`
+	Swagger     string               `json:"swagger"`
+	Info        Info                 `json:"info"`
+	Host        string               `json:"host"`
+	BasePath    string               `json:"basePath,omitempty"`
+	Schemes     []string             `json:"schemes,omitempty"`
+	Paths       map[string]*PathItem `json:"paths"` // Ignoring extensions for now
+	Definitions map[string]*Schema   `json:"definitions"`
 }
 
 type Info struct {

--- a/model/common.go
+++ b/model/common.go
@@ -4,6 +4,10 @@ type Swagger struct {
 	Swagger string `json:"swagger"`
 	Info    Info   `json:"info"`
 	Host    string `json:"host"`
+	BasePath string `json:"basePath,omitempty"`
+	Schemes []string `json:"schemes,omitempty"`
+	Paths   map[string]*PathItem `json:"paths"` // Ignoring extensions for now
+	Definitions map[string]*Schema `json:"definitions"`
 }
 
 type Info struct {
@@ -14,9 +18,9 @@ type Info struct {
 	// The Terms of Service for the API.
 	TermsOfService string `json:"termsOfService,omitempty"`
 	// The contact information for the exposed API.
-	Contact Contact `json:"contact"`
+	Contact *Contact `json:"contact,omitempty"`
 	// The license information for the exposed API.
-	License License `json:"license"`
+	License *License `json:"license,omitempty"`
 	// Required Provides the version of the application API (not to be confused with the specification version).
 	Version string `json:"version,omitempty"`
 }

--- a/model/header_orderedmap.go
+++ b/model/header_orderedmap.go
@@ -56,7 +56,7 @@ func (l HeaderMap) MarshalJSON() ([]byte, error) {
 		buf.WriteString("\"")
 		buf.WriteString(each.Name)
 		buf.WriteString("\": ")
-		data, err := json.MarshalIndent(each.Header,"","\t")
+		data, err := json.MarshalIndent(each.Header, "", "\t")
 		if err != nil {
 			return buf.Bytes(), err
 		}

--- a/model/model_validator.go
+++ b/model/model_validator.go
@@ -1,0 +1,166 @@
+package model
+
+import (
+	"errors"
+	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+type ValidatorMapper func(ValidationFields, string, reflect.Type)
+
+func nopValidator(_ ValidationFields, _ string, _ reflect.Type) {
+}
+
+func minMaxLengthValidator(item ValidationFields, validator string, t reflect.Type) {
+	re := regexp.MustCompile(`length\(([0-9]+)\|([0-9]+)\)`)
+	groups := re.FindStringSubmatch(validator)
+	min, _ := strconv.Atoi(groups[1])
+	max, _ := strconv.Atoi(groups[2])
+	if t.Kind() == reflect.String {
+		item.SetMinLength(min)
+		item.SetMaxLength(max)
+	}
+}
+
+func requiredValidator(item ValidationFields, validator string, t reflect.Type) {
+	if validator == "required" {
+		item.SetRequired(true)
+	} else {
+		item.SetRequired(false)
+	}
+}
+
+func rangeValidator(item ValidationFields, validator string, t reflect.Type) {
+	re := regexp.MustCompile(`range\(([0-9]+)\|([0-9]+)\)`)
+	groups := re.FindStringSubmatch(validator)
+	min, _ := strconv.Atoi(groups[1])
+	max, _ := strconv.Atoi(groups[2])
+
+	for t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+
+	switch t.Kind() {
+	case reflect.String:
+		item.SetMinLength(min)
+		item.SetMaxLength(max)
+	case reflect.Slice, reflect.Array:
+		item.SetMinItems(min)
+		item.SetMaxItems(max)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		item.SetMinimum(min)
+		item.SetMaximum(max)
+	default:
+	}
+}
+
+var (
+	validatorRegistry = map[string]ValidatorMapper{
+		"required":       requiredValidator,
+		"range":          rangeValidator,
+		"length":         minMaxLengthValidator,
+		"matches":        nopValidator,
+		"alpha":          nopValidator,
+		"alphanum":       nopValidator,
+		"ascii":          nopValidator,
+		"base64":         nopValidator,
+		"creditcard":     nopValidator,
+		"datauri":        nopValidator,
+		"dialstring":     nopValidator,
+		"dns":            nopValidator,
+		"email":          nopValidator,
+		"float":          nopValidator,
+		"fullwidth":      nopValidator,
+		"halfwidth":      nopValidator,
+		"hexadecimal":    nopValidator,
+		"hexcolor":       nopValidator,
+		"host":           nopValidator,
+		"int":            nopValidator,
+		"ip":             nopValidator,
+		"ipv4":           nopValidator,
+		"ipv6":           nopValidator,
+		"isbn10":         nopValidator,
+		"isbn13":         nopValidator,
+		"json":           nopValidator,
+		"latitude":       nopValidator,
+		"longitude":      nopValidator,
+		"lowercase":      nopValidator,
+		"mac":            nopValidator,
+		"multibyte":      nopValidator,
+		"null":           nopValidator,
+		"numeric":        nopValidator,
+		"port":           nopValidator,
+		"printableascii": nopValidator,
+		"requri":         nopValidator,
+		"requrl":         nopValidator,
+		"rgbcolor":       nopValidator,
+		"ssn":            nopValidator,
+		"semver":         nopValidator,
+		"uppercase":      nopValidator,
+		"url":            nopValidator,
+		"utfdigit":       nopValidator,
+		"utfletter":      nopValidator,
+		"utfletternum":   nopValidator,
+		"utfnumeric":     nopValidator,
+		"uuid":           nopValidator,
+		"uuidv3":         nopValidator,
+		"uuidv4":         nopValidator,
+		"uuidv5":         nopValidator,
+	}
+)
+
+type Token struct {
+	value string
+	err   error
+}
+
+func tokenize(tagValue string) chan *Token {
+	c := make(chan *Token)
+	go func() {
+		for tagValue != "" {
+			if strings.HasPrefix(tagValue, "matches(") {
+				index := strings.Index(tagValue, ")")
+				if index == -1 {
+					c <- &Token{"", errors.New("Invalid sequence")}
+				}
+				c <- &Token{tagValue[:index+1], nil}
+				if len(tagValue)-1 == index+1 {
+					break
+				}
+				tagValue = tagValue[index+2:]
+			} else {
+				index := strings.Index(tagValue, ",")
+				if index == -1 {
+					c <- &Token{tagValue[:], nil}
+					break
+				}
+				c <- &Token{tagValue[:index], nil}
+				tagValue = tagValue[index+1:]
+			}
+		}
+		close(c)
+	}()
+	return c
+}
+
+func MapToGoValidator(validationFields ValidationFields, valid string, reflectType reflect.Type) error {
+	c := tokenize(valid)
+
+	for token := range c {
+		if token.err != nil {
+			return token.err
+		}
+		val, ok := validatorRegistry[strings.Split(token.value, "(")[0]]
+		if ok {
+			val(validationFields, token.value, reflectType)
+		}
+	}
+	return nil
+}
+
+func newBoolPtr(val bool) *bool {
+	return &val
+}

--- a/model/model_validator_test.go
+++ b/model/model_validator_test.go
@@ -1,0 +1,47 @@
+package model
+
+import (
+	"testing"
+)
+
+func TestMinMaxValidator(t *testing.T) {
+	item := Schema{}
+	minMaxLengthValidator(&item, "length(12|14)", nil)
+	if *item.MinLength != 12 {
+		t.Fail()
+	}
+	if *item.MaxLength != 14 {
+		t.Fail()
+	}
+}
+
+func TestTokenizer(t *testing.T) {
+	input := "length(1|2),matches(.*,),alnum,matches(.*,),1234"
+	expected := []string{
+		"length(1|2)",
+		"matches(.*,)",
+		"alnum",
+		"matches(.*,)",
+		"1234",
+	}
+	tokens := tokenize(input)
+	for _, exp := range expected {
+		if exp != (<-tokens).value {
+			t.Fail()
+		}
+	}
+}
+
+func TestMinMaxValidatorMapping(t *testing.T) {
+	prop := Schema{}
+	err := MapToGoValidator(&prop, "length(2|4)", nil)
+	if err != nil {
+		t.Fail()
+	}
+	if *prop.MaxLength != 4 {
+		t.Fail()
+	}
+	if *prop.MinLength != 2 {
+		t.Fail()
+	}
+}

--- a/model/model_validator_test.go
+++ b/model/model_validator_test.go
@@ -2,11 +2,13 @@ package model
 
 import (
 	"testing"
+	"reflect"
 )
 
 func TestMinMaxValidator(t *testing.T) {
 	item := Schema{}
-	minMaxLengthValidator(&item, "length(12|14)", nil)
+	str := ""
+	minMaxLengthValidator(nil, &item, "length(12|14)", reflect.TypeOf(str), "")
 	if *item.MinLength != 12 {
 		t.Fail()
 	}
@@ -34,7 +36,8 @@ func TestTokenizer(t *testing.T) {
 
 func TestMinMaxValidatorMapping(t *testing.T) {
 	prop := Schema{}
-	err := MapToGoValidator(&prop, "length(2|4)", nil)
+	str := ""
+	err := MapToGoValidator(nil, &prop, "length(2|4)", reflect.TypeOf(str), "")
 	if err != nil {
 		t.Fail()
 	}

--- a/model/operation.go
+++ b/model/operation.go
@@ -9,14 +9,14 @@ type Operation struct {
 	// For maximum readability in the swagger-ui, this field SHOULD be less than 120 characters.
 	Summary string `json:"summary,omitempty"`
 	// A verbose explanation of the operation behavior. GFM syntax can be used for rich text representation.
-	Description  string                `json:"description,omitempty"`
+	Description  string                 `json:"description,omitempty"`
 	ExternalDocs *ExternalDocumentation `json:"externalDocs,omitempty"`
-	OperationId  string                `json:"operationId,omitempty"`
-	Consumes     []string              `json:"consumes,omitempty"`
-	Produces     []string              `json:"produces,omitempty"`
-	Parameters   []Parameter           `json:"parameters,omitempty"`
-	Responses    map[string]*Response  `json:"responses,omitempty"`
-	Schemes      []string              `json:"schemes,omitempty"`
-	Deprecated   bool                  `json:"deprecated"`
+	OperationId  string                 `json:"operationId,omitempty"`
+	Consumes     []string               `json:"consumes,omitempty"`
+	Produces     []string               `json:"produces,omitempty"`
+	Parameters   []Parameter            `json:"parameters,omitempty"`
+	Responses    map[string]*Response   `json:"responses,omitempty"`
+	Schemes      []string               `json:"schemes,omitempty"`
+	Deprecated   bool                   `json:"deprecated"`
 	Security     *SecurityDefinitionMap `json:"security,omitempty"`
 }

--- a/model/operation.go
+++ b/model/operation.go
@@ -4,19 +4,19 @@ package model
 type Operation struct {
 	// A list of tags for API documentation control.
 	// Tags can be used for logical grouping of operations by resources or any other qualifier.
-	Tags []string `json:"summary,tags"`
+	Tags []string `json:"tags,omitempty"`
 	// A short summary of what the operation does.
 	// For maximum readability in the swagger-ui, this field SHOULD be less than 120 characters.
 	Summary string `json:"summary,omitempty"`
 	// A verbose explanation of the operation behavior. GFM syntax can be used for rich text representation.
 	Description  string                `json:"description,omitempty"`
-	ExternalDocs ExternalDocumentation `json:"externalDocs,omitempty"`
+	ExternalDocs *ExternalDocumentation `json:"externalDocs,omitempty"`
 	OperationId  string                `json:"operationId,omitempty"`
 	Consumes     []string              `json:"consumes,omitempty"`
 	Produces     []string              `json:"produces,omitempty"`
 	Parameters   []Parameter           `json:"parameters,omitempty"`
-	Responses    ResponseMap           `json:"responses,omitempty"`
+	Responses    map[string]*Response  `json:"responses,omitempty"`
 	Schemes      []string              `json:"schemes,omitempty"`
 	Deprecated   bool                  `json:"deprecated"`
-	Security     SecurityDefinitionMap `json:"security"`
+	Security     *SecurityDefinitionMap `json:"security,omitempty"`
 }

--- a/model/operation_test.go
+++ b/model/operation_test.go
@@ -28,8 +28,9 @@ func TestOperation(t *testing.T) {
 	i := Response{
 		Description: "Invalid input",
 	}
-	m.Responses.Default(d)
-	m.Responses.Put("400", i)
+	m.Responses = map[string]*Response{}
+	m.Responses["Default"] = &d
+	m.Responses["400"] = &i
 
 	data, err := json.MarshalIndent(m, "", "\t")
 	if err != nil {

--- a/model/parameter.go
+++ b/model/parameter.go
@@ -10,7 +10,7 @@ type Parameter struct {
 	// Determines whether this parameter is mandatory.
 	Required bool `json:"required"`
 	// If in is body
-	Schema Schema `json:"schema"`
+	Schema *Schema `json:"schema"`
 
 	// If not in body uses fields below
 	// The type of the parameter. Since the parameter is not located at the request body, it is limited to simple types (that is, not an object).

--- a/model/path.go
+++ b/model/path.go
@@ -13,21 +13,21 @@ type PathItem struct {
 	// The referenced structure MUST be in the format of a Path Item Object.
 	// If there are conflicts between the referenced definition and this Path Item's definition,
 	// the behavior is undefined.
-	Ref string
+	Ref *string `json:"$ref,omitempty"`
 	// A definition of a GET operation on this path.
-	Get Operation
+	Get *Operation `json:"get,omitempty"`
 	// A definition of a PUT operation on this path.
-	Put Operation
+	Put *Operation `json:"put,omitempty"`
 	// A definition of a POST operation on this path.
-	Post Operation
+	Post *Operation `json:"post,omitempty"`
 	// A definition of a DELETE operation on this path.
-	Delete Operation
+	Delete *Operation `json:"delete,omitempty"`
 	// A definition of a OPTIONS operation on this path.
-	Options Operation
+	Options *Operation `json:"options,omitempty"`
 	// A definition of a HEAD operation on this path.
-	Head Operation
+	Head *Operation `json:"head,omitempty"`
 	// A definition of a PATCH operation on this path.
-	Patch Operation
+	Patch *Operation `json:"patch,omitempty"`
 	// A list of parameters that are applicable for all the operations described under this path
-	Parameters []Parameter
+	Parameters []*Parameter `json:"parameters,omitempty"`
 }

--- a/model/response.go
+++ b/model/response.go
@@ -2,8 +2,8 @@ package model
 
 type Response struct {
 	Description string                 `json:"description"`
-	Schema      *Schema                 `json:"schema,omitempty"`
-	Headers     *HeaderMap              `json:"headers,omitempty"`
+	Schema      *Schema                `json:"schema,omitempty"`
+	Headers     *HeaderMap             `json:"headers,omitempty"`
 	Examples    map[string]interface{} `json:"example,omitempty"`
 	//Extensions  interface{}            // TODO
 }

--- a/model/response.go
+++ b/model/response.go
@@ -2,10 +2,10 @@ package model
 
 type Response struct {
 	Description string                 `json:"description"`
-	Schema      Schema                 `json:"schema"`
-	Headers     HeaderMap              `json:"headers"`
-	Examples    map[string]interface{} `json:"example"`
-	Extensions  interface{}            // TODO
+	Schema      *Schema                 `json:"schema,omitempty"`
+	Headers     *HeaderMap              `json:"headers,omitempty"`
+	Examples    map[string]interface{} `json:"example,omitempty"`
+	//Extensions  interface{}            // TODO
 }
 
 func (m ResponseMap) Default(r Response) {

--- a/model/response_orderedmap.go
+++ b/model/response_orderedmap.go
@@ -9,7 +9,7 @@ import (
 
 // namedResponse associates a name with a Response
 type namedResponse struct {
-	Name   string
+	Name     string
 	Response Response
 }
 
@@ -56,7 +56,7 @@ func (l ResponseMap) MarshalJSON() ([]byte, error) {
 		buf.WriteString("\"")
 		buf.WriteString(each.Name)
 		buf.WriteString("\": ")
-		data, err := json.MarshalIndent(each.Response,"","\t")
+		data, err := json.MarshalIndent(each.Response, "", "\t")
 		if err != nil {
 			return buf.Bytes(), err
 		}

--- a/model/response_test.go
+++ b/model/response_test.go
@@ -4,9 +4,9 @@ import "testing"
 
 func TestResponses(t *testing.T) {
 	m := ResponseMap{}
-	r0 := Response{Description: "Unexpected error", Schema: Schema{Ref: "#/definitions/ErrorModel"}}
+	r0 := Response{Description: "Unexpected error", Schema: &Schema{Ref: "#/definitions/ErrorModel"}}
 	m.Put("default", r0)
-	r1 := Response{Description: "a pet to be returned", Schema: Schema{Ref: "#/definitions/Pet"}}
+	r1 := Response{Description: "a pet to be returned", Schema: &Schema{Ref: "#/definitions/Pet"}}
 	m.Put("200", r1)
 	data, err := m.MarshalJSON()
 	if err != nil {

--- a/model/schema.go
+++ b/model/schema.go
@@ -3,11 +3,11 @@ package model
 type ValidationFields interface {
 	SetMaximum(int)
 	SetMinimum(int)
-	SetRequired(bool)
 	SetMaxLength(int)
 	SetMinLength(int)
 	SetMaxItems(int)
 	SetMinItems(int)
+	AddRequired(string)
 }
 
 type Schema struct {
@@ -29,11 +29,11 @@ type Schema struct {
 	UniqueItems      *bool         `json:"uniqueItems,omitempty"`
 	MaxProperties    *int          `json:"maxProperties,omitempty"`
 	MinProperties    *int          `json:"minProperties,omitempty"`
-	Required         *bool         `json:"required,omitempty"`
+	Required         []string      `json:"required,omitempty"`
 	Enum             []interface{} `json:"enum,omitempty"`
 	Type             string        `json:"type,omitempty"`
 	// definitions were adjusted to the Swagger
-	Items                *Schema          `json:"items,omitempty"`
+	Items                *Schema            `json:"items,omitempty"`
 	AllOf                []*Schema          `json:"allOf,omitempty"`
 	Properties           map[string]*Schema `json:"properties,omitempty"`
 	AdditionalProperties *Schema            `json:"additionalProperties,omitempty"`
@@ -70,6 +70,6 @@ func (s *Schema) SetMinItems(m int) {
 	s.MinItems = &m
 }
 
-func (s *Schema) SetRequired(b bool) {
-	s.Required = &b
+func (s *Schema) AddRequired(property string) {
+	s.Required = append(s.Required, property)
 }

--- a/model/schema.go
+++ b/model/schema.go
@@ -1,5 +1,15 @@
 package model
 
+type ValidationFields interface {
+	SetMaximum(int)
+	SetMinimum(int)
+	SetRequired(bool)
+	SetMaxLength(int)
+	SetMinLength(int)
+	SetMaxItems(int)
+	SetMinItems(int)
+}
+
 type Schema struct {
 	Ref              string        `json:"$ref,omitempty"`
 	Format           string        `json:"format,omitempty"`
@@ -23,10 +33,10 @@ type Schema struct {
 	Enum             []interface{} `json:"enum,omitempty"`
 	Type             string        `json:"type,omitempty"`
 	// definitions were adjusted to the Swagger
-	Items                []Schema `json:"items,omitempty"`
-	AllOf                []Schema `json:"allOf,omitempty"`
-	Properties           []Schema `json:"properties,omitempty"`
-	AdditionalProperties []Schema `json:"additionalProperties,omitempty"`
+	Items                []*Schema          `json:"items,omitempty"`
+	AllOf                []*Schema          `json:"allOf,omitempty"`
+	Properties           map[string]*Schema `json:"properties,omitempty"`
+	AdditionalProperties *Schema            `json:"additionalProperties,omitempty"`
 	//PatternProperties    PatternMap `json:"patternProperties,omitempty"`
 	//  further schema documentation
 	Discriminator string                 `json:"discriminator,omitempty"`
@@ -36,7 +46,30 @@ type Schema struct {
 	Example       interface{}            `json:"example,omitempty"`
 }
 
-func (s Schema) SetMaximum(m int) Schema {
+func (s *Schema) SetMaximum(m int) {
 	s.Maximum = &m
-	return s
+}
+
+func (s *Schema) SetMinimum(m int) {
+	s.Minimum = &m
+}
+
+func (s *Schema) SetMaxLength(m int) {
+	s.MaxLength = &m
+}
+
+func (s *Schema) SetMinLength(m int) {
+	s.MinLength = &m
+}
+
+func (s *Schema) SetMaxItems(m int) {
+	s.MaxItems = &m
+}
+
+func (s *Schema) SetMinItems(m int) {
+	s.MinItems = &m
+}
+
+func (s *Schema) SetRequired(b bool) {
+	s.Required = &b
 }

--- a/model/schema.go
+++ b/model/schema.go
@@ -33,7 +33,7 @@ type Schema struct {
 	Enum             []interface{} `json:"enum,omitempty"`
 	Type             string        `json:"type,omitempty"`
 	// definitions were adjusted to the Swagger
-	Items                []*Schema          `json:"items,omitempty"`
+	Items                *Schema          `json:"items,omitempty"`
 	AllOf                []*Schema          `json:"allOf,omitempty"`
 	Properties           map[string]*Schema `json:"properties,omitempty"`
 	AdditionalProperties *Schema            `json:"additionalProperties,omitempty"`

--- a/model/securitydefinition_orderedmap.go
+++ b/model/securitydefinition_orderedmap.go
@@ -9,7 +9,7 @@ import (
 
 // namedSecurityDefinition associates a name with a SecurityDefinition
 type namedSecurityDefinition struct {
-	Name   string
+	Name               string
 	SecurityDefinition SecurityDefinition
 }
 
@@ -56,7 +56,7 @@ func (l SecurityDefinitionMap) MarshalJSON() ([]byte, error) {
 		buf.WriteString("\"")
 		buf.WriteString(each.Name)
 		buf.WriteString("\": ")
-		data, err := json.MarshalIndent(each.SecurityDefinition,"","\t")
+		data, err := json.MarshalIndent(each.SecurityDefinition, "", "\t")
 		if err != nil {
 			return buf.Bytes(), err
 		}

--- a/model/securityscheme_orderedmap.go
+++ b/model/securityscheme_orderedmap.go
@@ -9,7 +9,7 @@ import (
 
 // namedSecurityScheme associates a name with a SecurityScheme
 type namedSecurityScheme struct {
-	Name   string
+	Name           string
 	SecurityScheme SecurityScheme
 }
 
@@ -56,7 +56,7 @@ func (l SecuritySchemeMap) MarshalJSON() ([]byte, error) {
 		buf.WriteString("\"")
 		buf.WriteString(each.Name)
 		buf.WriteString("\": ")
-		data, err := json.MarshalIndent(each.SecurityScheme,"","\t")
+		data, err := json.MarshalIndent(each.SecurityScheme, "", "\t")
 		if err != nil {
 			return buf.Bytes(), err
 		}

--- a/schema_builder.go
+++ b/schema_builder.go
@@ -63,6 +63,10 @@ func (s *SchemaBuilder) build(t reflect.Type) *model.Schema {
 }
 func (s *SchemaBuilder) buildFromSlice(t reflect.Type) {
 	itemType := t.Elem()
+
+	if itemType.Kind() == reflect.Ptr {
+		itemType = itemType.Elem()
+	}
 	itemSchema := NewSchemaBuilder().Schemas(s.schemas).build(itemType)
 	switch itemType.Kind() {
 	case reflect.Struct:
@@ -100,7 +104,7 @@ func (s *SchemaBuilder) buildFromStruct(t reflect.Type) {
 		overrideType := getOverrideType(field)
 		if overrideType != "" {
 			s.schema.Properties[fieldName] = &model.Schema{Type: overrideType}
-			model.MapToGoValidator(s.schema.Properties[fieldName], field.Tag.Get("valid"), fieldType)
+			model.MapToGoValidator(s.schema, s.schema.Properties[fieldName], field.Tag.Get("valid"), fieldType, fieldName)
 			continue
 		}
 
@@ -109,9 +113,9 @@ func (s *SchemaBuilder) buildFromStruct(t reflect.Type) {
 		switch fieldType.Kind() {
 		case reflect.Struct:
 			s.schema.Properties[fieldName] = &model.Schema{Ref: ref(fieldType)}
-			model.MapToGoValidator(s.schema.Properties[fieldName], field.Tag.Get("valid"), fieldType)
+			model.MapToGoValidator(s.schema, s.schema.Properties[fieldName], field.Tag.Get("valid"), fieldType, fieldName)
 		default:
-			model.MapToGoValidator(fieldSchema, field.Tag.Get("valid"), fieldType)
+			model.MapToGoValidator(s.schema, fieldSchema, field.Tag.Get("valid"), fieldType, fieldName)
 			s.schema.Properties[fieldName] = fieldSchema
 		}
 	}

--- a/schema_builder.go
+++ b/schema_builder.go
@@ -53,7 +53,7 @@ func (s *SchemaBuilder) build(t reflect.Type) *model.Schema {
 	case reflect.Slice:
 		s.buildFromSlice(t)
 	case reflect.Map:
-		//p.buildFromMap(t)
+		s.buildFromMap(t)
 	case reflect.Struct:
 		s.buildFromStruct(t)
 	case reflect.Ptr:
@@ -61,6 +61,23 @@ func (s *SchemaBuilder) build(t reflect.Type) *model.Schema {
 	}
 	return s.schema
 }
+
+
+func (s *SchemaBuilder) buildFromMap(t reflect.Type) {
+	itemType := t.Elem()
+
+	if itemType.Kind() == reflect.Ptr {
+		itemType = itemType.Elem()
+	}
+	itemSchema := NewSchemaBuilder().Schemas(s.schemas).build(itemType)
+	switch itemType.Kind() {
+	case reflect.Struct:
+		s.schema.AdditionalProperties = &model.Schema{Ref: ref(itemType)}
+	default:
+		s.schema.AdditionalProperties = itemSchema
+	}
+}
+
 func (s *SchemaBuilder) buildFromSlice(t reflect.Type) {
 	itemType := t.Elem()
 

--- a/schema_builder.go
+++ b/schema_builder.go
@@ -66,9 +66,9 @@ func (s *SchemaBuilder) buildFromSlice(t reflect.Type) {
 	itemSchema := NewSchemaBuilder().Schemas(s.schemas).build(itemType)
 	switch itemType.Kind() {
 	case reflect.Struct:
-		s.schema.Items = []*model.Schema{{Ref: ref(itemType)}}
+		s.schema.Items = &model.Schema{Ref: ref(itemType)}
 	default:
-		s.schema.Items = []*model.Schema{itemSchema}
+		s.schema.Items = itemSchema
 	}
 }
 
@@ -119,7 +119,7 @@ func (s *SchemaBuilder) buildFromStruct(t reflect.Type) {
 
 // github.com/mcuadros/go-jsonschema-generator
 var mapping = map[reflect.Kind]string{
-	reflect.Bool:    "bool",
+	reflect.Bool:    "boolean",
 	reflect.Int:     "integer",
 	reflect.Int8:    "integer",
 	reflect.Int16:   "integer",

--- a/schema_builder.go
+++ b/schema_builder.go
@@ -78,7 +78,7 @@ func (s *SchemaBuilder) buildFromStruct(t reflect.Type) {
 		// find out the field name
 		field := t.Field(c)
 		fieldName := getFieldName(field)
-		if fieldName == "" {
+		if fieldName == ""  {
 			continue
 		}
 
@@ -90,7 +90,9 @@ func (s *SchemaBuilder) buildFromStruct(t reflect.Type) {
 		fieldSchema := NewSchemaBuilder().Schemas(s.schemas).build(fieldType)
 		if fieldType.Kind() == reflect.Struct {
 			s.schema.Properties[fieldName] = &model.Schema{Ref: ref(fieldType)}
+			model.MapToGoValidator(s.schema.Properties[fieldName], field.Tag.Get("valid"), fieldType)
 		} else {
+			model.MapToGoValidator(fieldSchema, field.Tag.Get("valid"), fieldType)
 			s.schema.Properties[fieldName] = fieldSchema
 		}
 	}

--- a/schema_builder_test.go
+++ b/schema_builder_test.go
@@ -26,6 +26,8 @@ type Annoted struct {
 	StructArray []Recursive
 	Rec         Recursive `valid:"required"`
 	IgnoreMe    string    `json:"-"`
+	StringMap   map[string]string `json:"stringMap"`
+	StructMap   map[string]*Recursive `json:"structMap"`
 }
 
 func TestSchemaPrimitives(t *testing.T) {
@@ -74,6 +76,18 @@ func TestAnnotedModel(t *testing.T) {
 	      },
 	      "ID": {
 	        "type": "string"
+	      },
+	      "structMap": {
+	        "type": "object",
+	        "additionalProperties": {
+	            "$ref": "#/definitions/Recursive"
+	         }
+	      },
+	      "stringMap": {
+	        "type": "object",
+	        "additionalProperties": {
+	            "type": "string"
+	         }
 	      },
 	      "IP": {
 	        "type": "string"

--- a/schema_builder_test.go
+++ b/schema_builder_test.go
@@ -16,14 +16,16 @@ type Recursive struct {
 }
 
 type Annoted struct {
-	Name    string  `description:"name" modelDescription:"a test"`
-	Happy   bool    `json:"happy"`
-	Stati   string  `enum:"off|on" default:"on" modelDescription:"more description" valid:"range(10|20)"`
-	ID      string  `unique:"true"`
-	FakeInt fakeint `type:"integer" valid:"required,range(3|4)"`
-	IP      net.IP  `type:"string"`
-	Rec     Recursive `valid:"required"`
-	IgnoreMe string `json:"-"`
+	Name        string  `description:"name" modelDescription:"a test"`
+	Happy       bool    `json:"happy"`
+	Stati       string  `enum:"off|on" default:"on" modelDescription:"more description" valid:"range(10|20)"`
+	ID          string  `unique:"true"`
+	FakeInt     fakeint `type:"integer" valid:"required,range(3|4)"`
+	IP          net.IP  `type:"string"`
+	StringArray []string
+	StructArray []Recursive
+	Rec         Recursive `valid:"required"`
+	IgnoreMe    string    `json:"-"`
 }
 
 func TestSchemaPrimitives(t *testing.T) {
@@ -71,7 +73,23 @@ func TestAnnotedModel(t *testing.T) {
 	        "type": "string"
 	      },
 	      "IP": {
-	        "type": "array"
+	        "type": "string"
+	      },
+	      "StringArray": {
+	        "type": "array",
+	        "items": [
+	          {
+	            "type": "string"
+	          }
+	        ]
+	      },
+	      "StructArray": {
+	        "type": "array",
+	        "items": [
+	          {
+	            "$ref": "#/definitions/Recursive"
+	          }
+	        ]
 	      },
 	      "Name": {
 	        "type": "string"

--- a/schema_builder_test.go
+++ b/schema_builder_test.go
@@ -43,7 +43,7 @@ func TestSchemaPrimitives(t *testing.T) {
 		{int64(42), `{"type":"integer"}`},
 		{uint32(42), `{"type":"integer"}`},
 		{uint64(42), `{"type":"integer"}`},
-		{false, `{"type":"bool"}`},
+		{false, `{"type":"boolean"}`},
 		{nil, `null`},
 	} {
 		b := NewSchemaBuilder()
@@ -62,12 +62,15 @@ func TestAnnotedModel(t *testing.T) {
 	expectedSchemasJson := `{
 	  "Annoted": {
 	    "type": "object",
+	    "required": [
+	      "FakeInt",
+	      "Rec"
+	    ],
 	    "properties": {
 	      "FakeInt": {
 	        "type": "integer",
 	        "minimum": 3,
-	        "maximum": 4,
-	        "required": true
+	        "maximum": 4
 	      },
 	      "ID": {
 	        "type": "string"
@@ -77,26 +80,23 @@ func TestAnnotedModel(t *testing.T) {
 	      },
 	      "StringArray": {
 	        "type": "array",
-	        "items": [
+	        "items":
 	          {
 	            "type": "string"
 	          }
-	        ]
 	      },
 	      "StructArray": {
 	        "type": "array",
-	        "items": [
+	        "items":
 	          {
 	            "$ref": "#/definitions/Recursive"
 	          }
-	        ]
 	      },
 	      "Name": {
 	        "type": "string"
 	      },
 	      "Rec": {
-	        "$ref": "#/definitions/Recursive",
-	        "required": true
+	        "$ref": "#/definitions/Recursive"
 	      },
 	      "Stati": {
 	        "type": "string",
@@ -104,7 +104,7 @@ func TestAnnotedModel(t *testing.T) {
 	        "maxLength": 20
 	      },
 	      "happy": {
-	        "type": "bool"
+	        "type": "boolean"
 	      }
 	    }
 	  },

--- a/swagger_test.go
+++ b/swagger_test.go
@@ -1,0 +1,23 @@
+package swagger2
+
+import (
+	"fmt"
+	"github.com/emicklei/swagger2/model"
+)
+
+func Example() {
+	prototype := Annoted{}
+	ref, definitions := NewSchemaBuilder().Build(prototype)
+
+	op := model.Operation{}
+	op.Produces = []string{"application/json"}
+	op.Consumes = []string{"application/json"}
+	op.Parameters = []model.Parameter{}
+	op.Responses = map[string]*model.Response{"200":&model.Response{Description:"test", Schema:ref}}
+	pathItem := model.PathItem{Get: &op}
+
+	swagger := model.NewSwagger()
+	modelBuilder := model.NewInfo().Title("test")
+	swagger.Definitions(definitions).Host("localhost").Path("/api/v1", &pathItem).Info(modelBuilder)
+	fmt.Println(doc(swagger.Build()))
+}

--- a/swagger_test.go
+++ b/swagger_test.go
@@ -13,7 +13,7 @@ func Example() {
 	op.Produces = []string{"application/json"}
 	op.Consumes = []string{"application/json"}
 	op.Parameters = []model.Parameter{}
-	op.Responses = map[string]*model.Response{"200":&model.Response{Description:"test", Schema:ref}}
+	op.Responses = map[string]*model.Response{"200": &model.Response{Description: "test", Schema: ref}}
 	pathItem := model.PathItem{Get: &op}
 
 	swagger := model.NewSwagger()


### PR DESCRIPTION
Hi,

I really like you go-restful package and I find it great that you want to extract the schema builder for swagger2. I started implementing the schema builder based on your structs.

First of all I added basic struct parsing support. Also added very basic support for govalidator `valid` tags.

Two questions before I go on with that:

1) I let the builder always return two arguments. The first one is a schema holding a "#/definitions/xyz"  reference if a struct was passed in. The second parameter contains the definitions map with all discovered schemas. What do you think about that?

2) Is [govalidator](https://github.com/asaskevich/govalidator) tags support something you are interested in?
